### PR TITLE
experiment: how do I put the Common.call function in a record and still please the compiler?

### DIFF
--- a/lib/account.ml
+++ b/lib/account.ml
@@ -11,3 +11,10 @@ let get_accounts ?(timeout = 3.) ~client () =
   let uri = endpoint_to_uri ~base_url:client.base_url Accounts in
   Common.call ~caller:"get_accounts" ~timeout
     ~parser:Account_j.accounts_of_string uri
+
+let get_accounts2 ?(timeout = 3.) ~(client : Account_t.accounts Types2.ctx2) ()
+    =
+  let uri = endpoint_to_uri ~base_url:client.base_url Accounts in
+  client.call ~caller:"get_accounts" ~timeout
+    ~parser:Account_j.accounts_of_string uri
+[@@ocaml.warning "-unused-value-declaration"]

--- a/lib/order.ml
+++ b/lib/order.ml
@@ -138,3 +138,11 @@ let order_status ?(timeout = 3.) ~client order_id =
   let uri = endpoint_to_uri ~base_url:client.base_url (Order_status order_id) in
   Common.call ~caller:"order_status" ~timeout
     ~parser:Order_j.order_status_of_string uri
+
+(* let order_status2
+     ?(timeout = 3.)
+     ~(client : Account_t.accounts Types2.ctx2)
+     order_id =
+   let uri = endpoint_to_uri ~base_url:client.base_url (Order_status order_id) in
+   client.call ~caller:"order_status" ~timeout
+     ~parser:Order_j.order_status_of_string uri *)

--- a/lib/test.ml
+++ b/lib/test.ml
@@ -1,0 +1,5 @@
+let my_ctx =
+  Types2.{ account_id = "arst"; base_url = "barst"; call = Common.call }
+
+let acc = Account.get_accounts2 ~client:my_ctx ()
+(* let ord = Order.order_status2 ~client:my_ctx () *)

--- a/lib/types2.ml
+++ b/lib/types2.ml
@@ -1,0 +1,14 @@
+type 'a ctx2 = {
+  account_id : string;
+  base_url : string;
+  call :
+    ?caller:string ->
+    ?timeout:float ->
+    ?meth:Cohttp.Code.meth ->
+    ?skip_verify:bool ->
+    ?headers:Cohttp.Header.t ->
+    ?body:Cohttp_lwt.Body.t ->
+    parser:(string -> 'a) ->
+    Uri.t ->
+    ('a, string) result Lwt.t;
+}


### PR DESCRIPTION
This is a (failed) attempt at breaking out the `Common.call` function into a `ctx` record.

Ideally this library would be agnostic to Lwt / Async / Eio etc. How do I go about doing that?